### PR TITLE
Configure high availability Traefik

### DIFF
--- a/kustomize/bases/traefik/helmchartconfig.yaml
+++ b/kustomize/bases/traefik/helmchartconfig.yaml
@@ -1,0 +1,9 @@
+apiVersion: helm.cattle.io/v1
+kind: HelmChartConfig
+metadata:
+  name: traefik
+  namespace: kube-system
+spec:
+  valuesContent: |-
+    deployment:
+      kind: DaemonSet

--- a/kustomize/bases/traefik/kustomization.yaml
+++ b/kustomize/bases/traefik/kustomization.yaml
@@ -1,3 +1,4 @@
 resources:
   - service.yaml
   - ingress.yaml
+  - helmchartconfig.yaml


### PR DESCRIPTION
By default K3S deploys Traefik only as a single node. By changing the deployment to DaemonSet it will be deployed in each node.

https://docs.k3s.io/helm#customizing-packaged-components-with-helmchartconfig