### PR TITLE
Make sure Postgres data persists

### DIFF
--- a/kustomize/bases/ghostfolio/postgres/statefulset.yaml
+++ b/kustomize/bases/ghostfolio/postgres/statefulset.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       name: postgres
-      # These are not needed by considered a good practice
+      # These are not needed but considered a good practice
       labels:
         app.kubernetes.io/name: postgres
         app.kubernetes.io/component: database

--- a/kustomize/bases/ghostfolio/postgres/statefulset.yaml
+++ b/kustomize/bases/ghostfolio/postgres/statefulset.yaml
@@ -24,10 +24,16 @@ spec:
         app.kubernetes.io/instance: ghostfolio-postgres
         app.kubernetes.io/version: "15.0"
     spec:
+      securityContext:
+        runAsUser: 70
+        runAsGroup: 70
+        fsGroup: 70
       containers:
         - name: postgres
-          image: postgres:15.0
+          image: postgres:15.0-alpine
           env:
+            - name: PGDATA
+              value: /postgresql/data
             # These are created automagically
             - name: POSTGRES_USER
               valueFrom:
@@ -71,7 +77,7 @@ spec:
               memory: 1024Mi
           volumeMounts:
             - name: data
-              mountPath: /var/lib/postgresql
+              mountPath: /postgresql
   volumeClaimTemplates:
     - metadata:
         name: data


### PR DESCRIPTION
The official Postgres image has a footgun. If persistent volume is mounted
to Postgres default /var/lib/postgresql the data will be lost first time the
pod is restarted.