### PR TITLE
Add tolerations for dedicated storage node

### DIFF
--- a/kustomize/bases/longhorn/download/longhorn.yaml
+++ b/kustomize/bases/longhorn/download/longhorn.yaml
@@ -4379,6 +4379,11 @@ spec:
         app.kubernetes.io/version: v1.6.2
         app: longhorn-manager
     spec:
+      tolerations:
+      - effect: NoSchedule
+        key: dedicated
+        operator: Equal
+        value: storage
       containers:
       - name: longhorn-manager
         image: longhornio/longhorn-manager:v1.6.2
@@ -4484,6 +4489,11 @@ spec:
         app.kubernetes.io/version: v1.6.2
         app: longhorn-driver-deployer
     spec:
+      tolerations:
+        - effect: NoSchedule
+          key: dedicated
+          operator: Equal
+          value: storage
       initContainers:
         - name: wait-longhorn-manager
           image: longhornio/longhorn-manager:v1.6.2
@@ -4567,6 +4577,11 @@ spec:
                   values:
                   - longhorn-ui
               topologyKey: kubernetes.io/hostname
+      tolerations:
+      - effect: NoSchedule
+        key: dedicated
+        operator: Equal
+        value: storage
       containers:
       - name: longhorn-ui
         image: longhornio/longhorn-ui:v1.6.2


### PR DESCRIPTION
Allows Longhorn to deploy to nodes which have been tainted as storage only nodes.

$ kubectl taint nodes storage-00 dedicated=storage:NoSchedule
